### PR TITLE
installing zip command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 LABEL maintainer Robert Peteuil <https://github.com/robertpeteuil>
 
-RUN apk --update add python py-pip groff less bash curl git && \
+RUN apk --update add python py-pip zip groff less bash curl git && \
     pip install -U awscli && \
     apk --purge -v del py-pip && \
     rm -rf `find / -regex '.*\.py[co]' -or -name apk`


### PR DESCRIPTION
The `rm -rf `find / -regex '.*\.py[co]' -or -name apk` step removes the apk command. This prevented us from using the apk command.

So added the zip command for installation.

